### PR TITLE
Update cookiecutter template via cruft

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,6 +1,6 @@
 {
   "template": "https://github.com/Ouranosinc/cookiecutter-pypackage",
-  "commit": "64eceda7d95aeb8937fa9961989d3d617a525c04",
+  "commit": "617b216e87e1ddf008fcca890dfd5dd1ee601f51",
   "checkout": null,
   "context": {
     "cookiecutter": {
@@ -17,6 +17,7 @@
       "use_conda": "y",
       "add_pyup_badge": "n",
       "make_docs": "y",
+      "add_translations": "y",
       "command_line_interface": "No command-line interface",
       "create_author_file": "y",
       "open_source_license": "MIT license",

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily
+      time: '12:00'
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: daily
+      time: '12:00'
+    open-pull-requests-limit: 10

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,20 @@
+# label rules used by .github/workflows/label.yml
+
+# label 'ci' all automation-related steps and files
+#   Since this repository is in itself an automation process to deploy a server instance,
+#   we refer here to CI as the 'meta' configuration files for managing the code and integrations with the repository,
+#   not configurations related to the deployment process itself.
+
+# Uncomment the following lines to enable the labeler (requires labels with the same name to exist in the repository)
+
+# label 'ci' all automation-related steps and files
+#'CI':
+#  - changed-files:
+#    - any-glob-to-any-file:
+#      - '.editorconfig'
+#      - '.flake8'
+#      - '.pre-commit-config.yaml'
+#      - '.yamllint.yml'
+#      - '.github/workflows/*'
+#      - 'tox.ini'
+#      - 'Makefile'

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -1,3 +1,8 @@
+# This workflow requires a personal access token named `BUMP_VERSION_TOKEN` with the following privileges:
+# - Contents: Read and Write
+# - Metadata: Read-Only
+# - Pull Requests: Read and Write
+
 name: "Bump Patch Version"
 
 on:
@@ -40,6 +45,15 @@ jobs:
       actions: read
       contents: write
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@eb238b55efaa70779f274895e782ed17c84f2895 # v2.6.1
+        with:
+          disable-sudo: true
+          egress-policy: block
+          allowed-endpoints: >
+            files.pythonhosted.org:443
+            github.com:443
+            pypi.org:443
       - uses: actions/checkout@v4.1.1
         with:
           persist-credentials: false
@@ -50,14 +64,24 @@ jobs:
         run: |
           git config --local user.email "bumpversion[bot]@hydrologie.com"
           git config --local user.name "bumpversion[bot]"
-      - name: Current Version
-        run: echo "current_version=$(grep -E '__version__'  xdatasets/__init__.py | cut -d ' ' -f3)"
-      - name: Bump Patch Version
+      - name: Install bump-my-version
         run: |
-          pip install bump-my-version
-          echo "Bumping version"
-          bump-my-version bump --tag patch
-          echo "new_version=$(grep -E '__version__'  xdatasets/__init__.py | cut -d ' ' -f3)"
+          python -m pip install "bump-my-version>=0.17.1"
+
+      - name: Current Version
+        run: |
+          bump-my-version show current_version
+          CURRENT_VERSION="$(grep -E '__version__' xdatasets/__init__.py | cut -d ' ' -f3)"
+          echo "CURRENT_VERSION=${CURRENT_VERSION}" >> $GITHUB_ENV
+      - name: Conditional Bump Version
+        run: |
+          if [[ ${{ env.CURRENT_VERSION }} =~ -dev(\.\d+)? ]]; then
+            echo "Development version (ends in 'dev(\.\d+)?'), bumping 'build' version"
+            bump-my-version show new_version --increment build
+          else
+            echo "Version is stable, bumping 'patch' version"
+            bump-my-version show new_version --increment patch
+          fi
       - name: Push Changes
         uses: ad-m/github-push-action@v0.8.0
         with:

--- a/.github/workflows/cache-cleaner.yml
+++ b/.github/workflows/cache-cleaner.yml
@@ -1,0 +1,47 @@
+# Example taken from https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#managing-caches
+name: Cleanup Caches on Pull Request Merge
+on:
+  pull_request:
+    types:
+      - closed
+
+permissions:  # added using https://github.com/step-security/secure-repo
+  contents: read
+
+jobs:
+  cleanup:
+    name: Cleanup
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@eb238b55efaa70779f274895e782ed17c84f2895 # v2.6.1
+        with:
+          disable-sudo: true
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            github.com:443
+            objects.githubusercontent.com:443
+
+      - uses: actions/checkout@v4.1.1
+
+      - name: Cleanup
+        run: |
+          gh extension install actions/gh-actions-cache
+
+          REPO=${{ github.repository }}
+          BRANCH="refs/pull/${{ github.event.pull_request.number }}/merge"
+
+          echo "Fetching list of cache key"
+          cacheKeysForPR=$(gh actions-cache list -R $REPO -B $BRANCH -L 100 | cut -f 1 )
+
+          ## Setting this to not fail the workflow while deleting cache keys.
+          set +e
+          echo "Deleting caches..."
+          for cacheKey in $cacheKeysForPR
+          do
+              gh actions-cache delete $cacheKey -R $REPO -B $BRANCH --confirm
+          done
+          echo "Done"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,31 @@
+# Dependency Review Action
+#
+# This Action will scan dependency manifest files that change as part of a Pull Request, surfacing known-vulnerable versions of the packages declared or updated in the PR. Once installed, if the workflow run is marked as required, PRs introducing known-vulnerable packages will be blocked from merging.
+#
+# Source repository: https://github.com/actions/dependency-review-action
+# Public documentation: https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/about-dependency-review#dependency-review-enforcement
+name: 'Dependency Review'
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@eb238b55efaa70779f274895e782ed17c84f2895 # v2.6.1
+        with:
+          disable-sudo: true
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            github.com:443
+
+      - name: 'Checkout Repository'
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+      - name: 'Dependency Review'
+        uses: actions/dependency-review-action@4901385134134e04cec5fbe5ddfe3b2c5bd5d976

--- a/.github/workflows/first-pull-request.yml
+++ b/.github/workflows/first-pull-request.yml
@@ -16,6 +16,14 @@ jobs:
       contents: read
       pull-requests: write
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@eb238b55efaa70779f274895e782ed17c84f2895 # v2.6.1
+        with:
+          disable-sudo: true
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+
       - uses: actions/github-script@v7.0.1
         with:
           script: |

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -1,0 +1,37 @@
+# This workflow will triage pull requests and apply a label based on the
+# paths that are modified in the pull request.
+#
+# To use this workflow, you will need to set up a .github/labeler.yml
+# file with configuration.  For more information, see:
+# https://github.com/actions/labeler/blob/master/README.md
+
+name: Labeler
+on:
+  pull_request_target:
+  # Note: potential security risk from this action using pull_request_target.
+  # Do not add actions in here which need a checkout of the repo, and do not use any caching in here.
+  # See: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target
+
+permissions:
+  contents: read
+
+jobs:
+  label:
+    name: Label
+    runs-on: ubuntu-latest
+    permissions:
+      checks: write
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@eb238b55efaa70779f274895e782ed17c84f2895 # v2.6.1
+        with:
+          disable-sudo: true
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+
+      - uses: actions/labeler@v5.0.0
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,12 +14,12 @@ on:
   pull_request:
 
 concurrency:
+  # For a given workflow, if we push to the same branch, cancel all previous builds on that branch except on master.
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:
   contents: read
-  pull-requests: read
 
 jobs:
   lint:
@@ -30,10 +30,6 @@ jobs:
         python-version:
           - "3.x"
     steps:
-      - name: Cancel previous runs
-        uses: styfle/cancel-workflow-action@0.12.1
-        with:
-          access_token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/checkout@v4.1.1
       - name: Set up Python${{ matrix.python-version }}
         uses: actions/setup-python@v5.0.0
@@ -63,6 +59,8 @@ jobs:
             python-version: "3.10"
           - tox-env: "py311"
             python-version: "3.11"
+          - tox-env: "py312"
+            python-version: "3.12"
     steps:
       - uses: actions/checkout@v4.1.1
       - name: Install NetCDF
@@ -143,6 +141,10 @@ jobs:
 #    runs-on: ubuntu-latest
 #    container: python:3-slim
 #    steps:
+#      - name: Harden Runner
+#        uses: step-security/harden-runner@eb238b55efaa70779f274895e782ed17c84f2895 # v2.6.1
+#        with:
+#          egress-policy: audit
 #      - name: Coveralls Finished
 #        run: |
 #          pip install --upgrade coveralls

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -17,6 +17,10 @@ jobs:
       # IMPORTANT: this permission is mandatory for trusted publishing
       id-token: write
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@eb238b55efaa70779f274895e782ed17c84f2895 # v2.6.1
+        with:
+          egress-policy: audit
       - uses: actions/checkout@v4.1.1
       - name: Set up Python3
         uses: actions/setup-python@v5.0.0

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,82 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by separate terms of service, privacy
+# policy, and support documentation.
+
+name: Scorecard supply-chain security
+on:
+  # For Branch-Protection check. Only the default branch is supported. See
+  # https://github.com/ossf/scorecard/blob/main/docs/checks.md#branch-protection
+  branch_protection_rule:
+  # To guarantee Maintained check is occasionally updated. See
+  # https://github.com/ossf/scorecard/blob/main/docs/checks.md#maintained
+  schedule:
+    - cron: '41 8 * * 4'
+  push:
+    branches:
+      - main
+
+# Declare default permissions as read only.
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      # Needed to upload the results to code-scanning dashboard.
+      security-events: write
+      # Needed to publish results and get a badge (see publish_results below).
+      id-token: write
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@eb238b55efaa70779f274895e782ed17c84f2895 # v2.6.1
+        with:
+          disable-sudo: true
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            api.osv.dev:443
+            api.securityscorecards.dev:443
+            fulcio.sigstore.dev:443
+            github.com:443
+            oss-fuzz-build-logs.storage.googleapis.com:443
+            rekor.sigstore.dev:443
+            tuf-repo-cdn.sigstore.dev:443
+            www.bestpractices.dev:443
+
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@0864cf19026789058feabb7e87baa5f140aac736
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # This job step requires a personal access token named `OPENSSF_SCORECARD_TOKEN` with the following privileges:
+          # - Administration: Read-Only
+          # - Metadata: Read-Only
+          # - Webhooks: Read-Only
+          # To create the PAT, follow the steps in https://github.com/ossf/scorecard-action#authentication-with-pat.
+          repo_token: ${{ secrets.OPENSSF_SCORECARD_TOKEN }}
+
+          # Public repositories:
+          #   - Publish results to OpenSSF REST API for easy access by consumers
+          #   - Allows the repository to include the Scorecard badge.
+          #   - See https://github.com/ossf/scorecard-action#publishing-results.
+          publish_results: true
+
+      # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
+      # format to the repository Actions tab.
+      - name: Upload artifact
+        uses: actions/upload-artifact@694cdabd8bdb0f10b2cea11669e1bf5453eed0a6
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      # Upload the results to GitHub's code scanning dashboard.
+      - name: Upload to code-scanning
+        uses: github/codeql-action/upload-sarif@e5f05b81d5b6ff8cfa111c80c22c5fd02a384118  # 3.23.0
+        with:
+          sarif_file: results.sarif

--- a/.github/workflows/tag-testpypi.yml
+++ b/.github/workflows/tag-testpypi.yml
@@ -16,6 +16,10 @@ jobs:
     permissions:
       contents: write
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@eb238b55efaa70779f274895e782ed17c84f2895 # v2.6.1
+        with:
+          egress-policy: audit
       - name: Checkout code
         uses: actions/checkout@v4.1.1
       - name: Create Release
@@ -24,8 +28,8 @@ jobs:
           # This token is provided by Actions, you do not need to create your own token
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ github.ref }}
-          name: Release ${{ github.ref }}
+          tag_name: ${{ github.ref_name }}
+          name: Release ${{ github.ref_name }}
           draft: true
           prerelease: false
 
@@ -37,6 +41,10 @@ jobs:
       # IMPORTANT: this permission is mandatory for trusted publishing
       id-token: write
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@eb238b55efaa70779f274895e782ed17c84f2895 # v2.6.1
+        with:
+          egress-policy: audit
       - uses: actions/checkout@v4.1.1
       - name: Set up Python3
         uses: actions/setup-python@v5.0.0

--- a/.github/workflows/workflow-warning.yml
+++ b/.github/workflows/workflow-warning.yml
@@ -1,0 +1,69 @@
+name: Workflow Changes Warnings
+
+on:
+  # Note: potential security risk from this action using pull_request_target.
+  # Do not add actions in here which need a checkout of the repo, and do not use any caching in here.
+  # See: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - synchronize
+    paths:
+      - .github/workflows/*.yml
+
+permissions:
+  contents: read
+
+jobs:
+  comment-concerning-workflow-changes:
+    name: Comment Concerning Workflow Changes
+    runs-on: ubuntu-latest
+    if: |
+      (github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name)
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@eb238b55efaa70779f274895e782ed17c84f2895 # v2.6.1
+        with:
+          disable-sudo: true
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+      - name: Find comment
+        uses: peter-evans/find-comment@a54c31d7fa095754bfef525c0c8e5e5674c4b4b1 # v2.4.0
+        id: fc
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: |
+            This Pull Request modifies GitHub workflows and is coming from a fork.
+      - name: Create comment
+        if: |
+          (steps.fc.outputs.comment-id == '') &&
+          (!contains(github.event.pull_request.labels.*.name, 'approved')) &&
+          (github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name)
+        uses: peter-evans/create-or-update-comment@23ff15729ef2fc348714a3bb66d2f655ca9066f2 # v3.1.0
+        with:
+          comment-id: ${{ steps.fc.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            > **Warning**
+            > This Pull Request modifies GitHub Workflows and is coming from a fork.
+            **It is very important for the reviewer to ensure that the workflow changes are appropriate.**
+          edit-mode: replace
+      - name: Update comment
+        if: |
+          contains(github.event.pull_request.labels.*.name, 'approved')
+        uses: peter-evans/create-or-update-comment@23ff15729ef2fc348714a3bb66d2f655ca9066f2 # v3.1.0
+        with:
+          comment-id: ${{ steps.fc.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            > **Note**
+            > Changes have been approved by a maintainer.
+          reactions: |
+            hooray
+          edit-mode: append

--- a/.gitignore
+++ b/.gitignore
@@ -91,6 +91,8 @@ instance/
 
 # Sphinx documentation
 docs/_build/
+docs/apidoc/modules.rst
+docs/apidoc/xdatasets*.rst
 
 # PyBuilder
 target/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,7 @@ repos:
     hooks:
       - id: rst-inline-touching-normal
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 23.12.1
+    rev: 24.1.1
     hooks:
       - id: black
   - repo: https://github.com/PyCQA/isort
@@ -37,7 +37,7 @@ repos:
     hooks:
       - id: isort
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.1.13
+    rev: v0.1.14
     hooks:
       - id: ruff
   - repo: https://github.com/pycqa/flake8
@@ -53,14 +53,14 @@ repos:
         args: [ '--py38-plus' ]
         additional_dependencies: [ 'pyupgrade==3.15.0' ]
       - id: nbqa-black
-        additional_dependencies: [ 'black==23.12.1' ]
+        additional_dependencies: [ 'black==24.1.1' ]
       - id: nbqa-isort
         additional_dependencies: [ 'isort==5.13.2' ]
   - repo: https://github.com/keewis/blackdoc
     rev: v0.3.9
     hooks:
       - id: blackdoc
-        additional_dependencies: [ 'black==23.12.1' ]
+        additional_dependencies: [ 'black==24.1.1' ]
   - repo: https://github.com/adrienverge/yamllint.git
     rev: v1.33.0
     hooks:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -17,7 +17,7 @@ build:
   jobs:
     pre_build:
       - sphinx-apidoc -o docs/apidoc --private --module-first xdatasets
-      - sphinx-build -M gettext docs docs/_build
+#      - sphinx-build -M gettext docs docs/_build
 
 conda:
   environment: environment-docs.yml

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -14,6 +14,10 @@ build:
   os: ubuntu-22.04
   tools:
     python: "mambaforge-22.9"
+  jobs:
+    pre_build:
+      - sphinx-apidoc -o docs/apidoc --private --module-first xdatasets
+      - sphinx-build -M gettext docs docs/_build
 
 conda:
   environment: environment-docs.yml

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,18 @@
 Changelog
 =========
 
+v0.3.5 (unreleased)
+-------------------
+
+* The `cookiecutter` template has been updated to the latest commit via `cruft`. (:pull:`52`):
+    * `xdatasets` is now `Semantic Version v2.0.0 <https://semver.org/spec/v2.0.0.html>`_-compliant
+    * Added a few workflows (Changed file labelling, Cache cleaning, Dependency Scanning, OpenSSF Scorecard)
+    * Workflows now use the `tep-security/harden-runner` action to security harden the runner environment
+    * Reorganized README and added a few badges
+    * Updated pre-commit hook versions
+    * Formatting tools (`black`, `blackdoc`, `isort`) are now pinned to their pre-commit version equivalents
+    * `actions-version-updater.yml` has been replaced by `dependabot`
+
 v0.3.4 (2024-01-31)
 -------------------
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -160,7 +160,7 @@ To run specific code style checks::
     $ ruff xdatasets tests
     $ flake8 xdatasets tests
 
-To get ``black``, ``isort ``blackdoc``, ``ruff``, and ``flake8`` (with plugins ``flake8-alphabetize`` and ``flake8-rst-docstrings``) simply install them with `pip` (or `conda`) into your environment.
+To get ``black``, ``isort``, ``blackdoc``, ``ruff``, and ``flake8`` (with plugins ``flake8-alphabetize`` and ``flake8-rst-docstrings``) simply install them with `pip` (or `conda`) into your environment.
 
 Versioning/Tagging
 ------------------
@@ -175,18 +175,14 @@ A reminder for the **maintainers** on how to deploy. This section is only releva
 #. Update the `CHANGES.rst` file to change the `Unreleased` section to the current date.
 #. Bump the version in your branch to the next version (e.g. `v0.1.0 -> v0.2.0`)::
 
-    .. code-block:: shell
-
-        $ bump-my-version bump minor # In most cases, we will be releasing a minor version
-        $ git push
+    $ bump-my-version bump minor # In most cases, we will be releasing a minor version
+    $ git push
 
 #. Create a pull request from your branch to `main`.
-#. Once the pull request is merged, create a new release on GitHub. On the main branch, run:
+#. Once the pull request is merged, create a new release on GitHub. On the main branch, run::
 
-    .. code-block:: shell
-
-        $ git tag v0.2.0
-        $ git push --tags
+    $ git tag v0.2.0
+    $ git push --tags
 
    This will trigger a GitHub workflow to build the package and upload it to TestPyPI. At the same time, the GitHub workflow will create a draft release on GitHub. Assuming that the workflow passes, the final release can then be published on GitHub by finalizing the draft release.
 

--- a/README.rst
+++ b/README.rst
@@ -2,21 +2,17 @@
 Xdatasets
 =========
 
-.. image:: https://img.shields.io/pypi/v/xdatasets.svg
-        :target: https://pypi.python.org/pypi/xdatasets
-        :alt: PyPI
-
-.. image:: https://github.com/hydrologie/xdatasets/actions/workflows/main.yml/badge.svg
-        :target: https://github.com/hydrologie/xdatasets/actions
-        :alt: Build Status
-
-.. image:: https://readthedocs.org/projects/xdatasets/badge/?version=latest
-        :target: https://xdatasets.readthedocs.io/en/latest/?version=latest
-        :alt: Documentation Status
-
-.. image:: https://img.shields.io/github/license/hydrologie/xdatasets.svg
-        :target: https://github.com/hydrologie/xdatasets/blob/master/LICENSE
-        :alt: License
++----------------------------+-----------------------------------------------------+
+| Versions                   | |pypi| |versions|                                   |
++----------------------------+-----------------------------------------------------+
+| Documentation and Support  | |docs|                                              |
++----------------------------+-----------------------------------------------------+
+| Open Source                | |license| |ossf|                                    |
++----------------------------+-----------------------------------------------------+
+| Coding Standards           | |black| |ruff| |pre-commit|                         |
++----------------------------+-----------------------------------------------------+
+| Development Status         | |status| |build| |coveralls|                        |
++----------------------------+-----------------------------------------------------+
 
 Easy access to Earth observation datasets with xarray.
 
@@ -35,3 +31,48 @@ This package was created with Cookiecutter_ and the `Ouranosinc/cookiecutter-pyp
 
 .. _Cookiecutter: https://github.com/cookiecutter/cookiecutter
 .. _`Ouranosinc/cookiecutter-pypackage`: https://github.com/Ouranosinc/cookiecutter-pypackage
+
+
+.. |black| image:: https://img.shields.io/badge/code%20style-black-000000.svg
+        :target: https://github.com/psf/black
+        :alt: Python Black
+
+.. |build| image:: https://github.com/hydrologie/xdatasets/actions/workflows/main.yml/badge.svg
+        :target: https://github.com/hydrologie/xdatasets/actions
+        :alt: Build Status
+
+.. |coveralls| image:: https://coveralls.io/repos/github/hydrologie/xdatasets/badge.svg
+        :target: https://coveralls.io/github/hydrologie/xdatasets
+        :alt: Coveralls
+
+.. |docs| image:: https://readthedocs.org/projects/xdatasets/badge/?version=latest
+        :target: https://xdatasets.readthedocs.io/en/latest/?version=latest
+        :alt: Documentation Status
+
+.. |license| image:: https://img.shields.io/github/license/hydrologie/xdatasets.svg
+        :target: https://github.com/hydrologie/xdatasets/blob/main/LICENSE
+        :alt: License
+
+.. |ossf| image:: https://api.securityscorecards.dev/projects/github.com/hydrologie/xdatasets/badge
+        :target: https://securityscorecards.dev/viewer/?uri=github.com/hydrologie/xdatasets
+        :alt: OpenSSF Scorecard
+
+.. |pre-commit| image:: https://results.pre-commit.ci/badge/github/hydrologie/xdatasets/main.svg
+        :target: https://results.pre-commit.ci/latest/github/hydrologie/xdatasets/main
+        :alt: pre-commit.ci status
+
+.. |pypi| image:: https://img.shields.io/pypi/v/xdatasets.svg
+        :target: https://pypi.python.org/pypi/xdatasets
+        :alt: PyPI
+
+.. |ruff| image:: https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json
+        :target: https://github.com/astral-sh/ruff
+        :alt: Ruff
+
+.. |status| image:: https://www.repostatus.org/badges/latest/active.svg
+        :target: https://www.repostatus.org/#active
+        :alt: Project Status: Active – The project has reached a stable, usable state and is being actively developed.
+
+.. |versions| image:: https://img.shields.io/pypi/pyversions/xdatasets.svg
+        :target: https://pypi.python.org/pypi/xdatasets
+        :alt: Supported Python Versions

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -97,6 +97,10 @@ release = xdatasets.__version__
 # Usually you set "language" from the command line for these cases.
 language = "en"
 
+# Sphinx-intl configuration
+locale_dirs = ["locales/"]
+gettext_compact = False  # optional
+
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This patterns also effect to html_static_path and html_extra_path

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -19,10 +19,15 @@ The genesis of this project can be traced back to a crucial requirement of effor
    installation
    usage
    notebooks/getting_started
-   apidoc/modules
    contributing
    authors
    changes
+
+.. toctree::
+   :maxdepth: 1
+   :caption: All Modules
+
+   apidoc/modules
 
 .. Indices and tables
 .. ==================

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -7,3 +7,9 @@ In this user guide, you will find detailed descriptions and examples that descri
 .. note::
 
     This user guide is a work in progress. If you have any questions or suggestions, please feel free to open an issue on the `xdatasets GitHub Issues page <https://github.com/hydrologie/xdatasets/issues>`_.
+
+To use xdatasets in a project:
+
+.. code-block:: python
+
+    import xdatasets

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -22,16 +22,16 @@ dependencies:
   - xarray >=2023.1
   - zarr
   # Dev tools and testing
-  - black >=23.11.0
-  - blackdoc >=0.3.9
-  - bump-my-version >=0.12.0
-  - coverage >=6.2.0,<7.0.0
+  - black ==24.1.1
+  - blackdoc ==0.3.9
+  - bump-my-version >=0.17.1
+  - coverage >=6.2.0,<8.0.0
   - coveralls >=3.3.1
   - flake8 >=6.1.0
   - flake8-rst-docstrings >=0.3.0
-  - flit
-  - isort >=5.12.0
-  - pip >=23.1.2
+  - flit >=3.9.0
+  - isort ==5.13.2
+  - pip >=23.3.0
   - pre-commit >=3.3.2
   - pytest >=7.3.1
   - pytest-cov>=4.0.0

--- a/environment-docs.yml
+++ b/environment-docs.yml
@@ -30,5 +30,6 @@ dependencies:
   - sphinx-click
   - sphinx-codeautolink
   - sphinx-copybutton
+  - sphinx-intl
   - sphinxcontrib-confluencebuilder
   - xagg

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ classifiers = [
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
   "Topic :: Scientific/Engineering :: Hydrology",
   "Programming Language :: Python :: Implementation :: CPython"
 ]
@@ -66,18 +67,18 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
   # Dev tools and testing
-  "black[jupyter]>=23.11.0",
-  "blackdoc>=0.3.9",
-  "bump-my-version>=0.12.0",
+  "black==24.1.1",
+  "blackdoc==0.3.9",
+  "bump-my-version>=0.17.1",
   "coverage",
   "coverage>=6.2.2,<7.0.0",
   "coveralls>=3.3.1",
   "flake8-alphabetize>=0.0.21",
   "flake8-rst-docstrings>=0.3.0",
   "flake8>=6.1.0",
-  "flit",
+  "flit>=3.9.0",
   "ipython<8.0", # this needed when testing see #1005
-  "isort>=5.12.0",
+  "isort==5.13.2",
   "mypy",
   "nbval",
   "pip>=23.1.2",
@@ -111,6 +112,7 @@ docs = [
   "s3fs",
   "sphinx-codeautolink",
   "sphinx-copybutton",
+  "sphinx-intl",
   "sphinx-rtd-theme>=1.0",
   "sphinx>=7.0",
   "sphinxcontrib-confluencebuilder"
@@ -132,17 +134,22 @@ target-version = [
   "py38",
   "py39",
   "py310",
-  "py311"
+  "py311",
+  "py312"
 ]
 
 [tool.bumpversion]
 current_version = "0.3.4"
 commit = true
+commit_args = "--no-verify"
 tag = false
 tag_name = "v{new_version}"
 allow_dirty = false
-serialize = ["{major}.{minor}.{patch}"]
-parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
+parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(\\-(?P<release>[a-z]+)(\\.(?P<build>\\d+)))?"
+serialize = [
+  "{major}.{minor}.{patch}-{release}.{build}",
+  "{major}.{minor}.{patch}"
+]
 
 [[tool.bumpversion.files]]
 filename = "xdatasets/__init__.py"
@@ -158,6 +165,16 @@ replace = "__version__ = \"{new_version}\""
 filename = ".cruft.json"
 search = "\"version\": \"{current_version}\""
 replace = "\"version\": \"{new_version}\""
+
+[tool.bumpversion.parts.build]
+independent = false
+
+[tool.bumpversion.parts.release]
+optional_value = "release"
+values = [
+  "dev",
+  "release"
+]
 
 [tool.coverage.run]
 relative_files = true
@@ -201,7 +218,8 @@ exclude = [
   ".yamllint.yaml",
   "docs/_*",
   "docs/apidoc/modules.rst",
-  "docs/apidoc/xdatasets*.rst"
+  "docs/apidoc/xdatasets*.rst",
+  "docs/locales"
 ]
 
 [tool.isort]

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 min_version = 4.0
 envlist =
     lint
-    py{38,39,310,311}
+    py{38,39,310,311,312}
     docs
     coveralls
 requires =
@@ -14,10 +14,10 @@ opts =
 [testenv:lint]
 skip_install = True
 deps =
-    black[jupyter]
-    blackdoc
-    isort
-    flake8
+    black == 24.1.1
+    blackdoc == 0.3.9
+    isort == 5.13.2
+    flake8 >= 7.0.0
     ruff
 commands =
     make lint


### PR DESCRIPTION
<!-- Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
  - This PR fixes #xyz
- [ ] (If applicable) Documentation has been added / updated (for bug fixes / features).
- [ ] (If applicable) Tests have been added.
- [x] CHANGES.rst has been updated (with summary of main changes).
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added.

### What kind of change does this PR introduce?

* Updates the cookiecutter to the latest commits
* `xdatasets` is now Semantic Version v2.0.0-compliant
* Added a few workflows (Change file labelling, Cache cleaning, Dependency scans, OpenSSF Scorecard)
* Updated pre-commit hook versions
* Formatting tools are now pinned to their pre-commit equivalents
* `actions-version-updater.yml` has been replaced by `dependabot`

### Does this PR introduce a breaking change?

Boilerplate documentation is largely unchanged. Workflows are now more a bit more elegant, including automatic labelling, warnings about unsafe changes to workflows, security-related changes, etc.

`actions-versions-updater.yml` has been replaced with `Dependendabot` (it's just better).

There's support for evaluating the OpenSSF Scorecard (this can be disabled if we want).

Code formatting tools are now hard-pinned. These need to be kept in sync with changes from `pre-commit`. `Dependabot` should do this task automatically via Pull Requests.

Versioning scheme is now SemVer 2.0-compliant:
* If the version doesn't end in `-dev` or `-dev.##`, `$ bump-my-version bump patch` will be called. This will set the version at `X.Y.Z+1-dev`. Otherwise, `$ bump-my-version bump build` will be called. This is all automated by the `bump-version.yml`.

When the version is ready for a release, it's up to the maintainer to call the following:
* `$ bump-my-version bump release` (for a patch release; i.e. `1.2.0` → `1.2.1`) or
* `$ bump-my-version bump minor` then `$ bump-my-version bump release` (for a minor release; i.e. `1.2.0` → `1.3.0`)

### Other information:

https://github.com/Ouranosinc/cookiecutter-pypackage/pull/30