### PR TITLE
Fix GitHub docs deployment, reduce redundant folder structure, pin intake below v2.0

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -43,4 +43,4 @@ jobs:
         uses: JamesIves/github-pages-deploy-action@v4.5.0
         with:
           branch: gh-pages # The branch the action should deploy to.
-          folder: docs/_build/html # The folder the action should deploy.
+          folder: docs/_build/en/html # The folder the action should deploy.

--- a/Makefile
+++ b/Makefile
@@ -93,13 +93,13 @@ linkcheck: autodoc ## run checks over all external links found throughout the do
 	$(MAKE) -C docs linkcheck
 
 docs: autodoc ## generate Sphinx HTML documentation, including API docs
-	$(MAKE) -C docs html BUILDDIR="_build/html/en"
+	$(MAKE) -C docs html BUILDDIR="_build/en"
 ifneq ("$(wildcard $(LOCALES))","")
 	${MAKE} -C docs gettext
-	$(MAKE) -C docs html BUILDDIR="_build/html/fr" SPHINXOPTS="-D language='fr'"
+	$(MAKE) -C docs html BUILDDIR="_build/fr" SPHINXOPTS="-D language='fr'"
 endif
 ifndef READTHEDOCS
-	$(BROWSER) docs/_build/html/en/html/index.html
+	$(BROWSER) docs/_build/en/html/index.html
 endif
 
 servedocs: docs ## compile the docs watching for changes

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -8,7 +8,7 @@ dependencies:
   - dask
   - dask-geopandas
   - geopandas
-  - intake
+  - intake <2.0
   - intake-geopandas
   - intake-xarray >=0.6.1
   - ipykernel

--- a/environment-docs.yml
+++ b/environment-docs.yml
@@ -10,7 +10,7 @@ dependencies:
   - furo
   - geoviews
   - hvplot
-  - intake
+  - intake <2.0.0
   - intake-geopandas
   - intake-xarray >=0.6.1
   - ipykernel

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dependencies = [
   "dask[array]>=2.6",
   "dask-geopandas",
   "geopandas",
-  "intake",
+  "intake<2.0.0",
   "intake-xarray>=0.6.1",
   "intake-geopandas",
   "ipython",


### PR DESCRIPTION
<!-- Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
  - This PR fixes #64 
- [ ] (If applicable) Documentation has been added / updated (for bug fixes / features).
- [ ] (If applicable) Tests have been added.
- [ ] CHANGES.rst has been updated (with summary of main changes).
  - [ ] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added.

### What kind of change does this PR introduce?

* Points the GitHub Docs deployment workflow at the right folder.
* Reduces the number of folder levels (should be ported to cookiecutter as well)
* Pins intake below v2.0

### Does this PR introduce a breaking change?

No.

### Other information:

PVI @RondeauG 

New `intake` just dropped; Doesn't seem to be compatible with some dependencies.
https://pypi.org/project/intake/2.0.0/

More information: https://github.com/intake/intake/blob/master/README_refactor.md