### PR TITLE
Bugfix for `unique_id` in `clip_polygon`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,7 +18,7 @@ Changes
     * A new pre-commit hook and linting step for validating numpy docstrings has been added (`numpydoc`).
     * All `pip`-based dependencies used to run in CI are now managed by a CI/requirements_ci.txt that uses hashes of packages for security.
     * Documentation has been added for ``$ make initialize-translations``.
-* Fixed a bug where `clip_polygon` would not work if not given a `unique_id` during a `Query`. (:pull:`143).
+* Fixed a bug where `clip_polygon` would not work if not given a `unique_id` during a `Query`. (:pull:`143`).
 
 .. _changes_0.3.6:
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,7 +7,7 @@ Changelog
 v0.3.7 (unreleased)
 -------------------
 
-Contributors: Trevor James Smith (:user:`Zeitsperre`)
+Contributors: Trevor James Smith (:user:`Zeitsperre`), Gabriel Rondeau-Genesse (:user:`RondeauG`)
 
 Changes
 ^^^^^^^
@@ -18,6 +18,7 @@ Changes
     * A new pre-commit hook and linting step for validating numpy docstrings has been added (`numpydoc`).
     * All `pip`-based dependencies used to run in CI are now managed by a CI/requirements_ci.txt that uses hashes of packages for security.
     * Documentation has been added for ``$ make initialize-translations``.
+* Fixed a bug where `clip_polygon` would not work if not given a `unique_id` during a `Query`. (:pull:`143).
 
 .. _changes_0.3.6:
 

--- a/src/xdatasets/spatial.py
+++ b/src/xdatasets/spatial.py
@@ -97,7 +97,7 @@ def clip_by_polygon(ds, space, dataset_name):
 
     data = xr.concat(arrays, dim="geom")
 
-    if "unique_id" in space:
+    if space.get("unique_id") is not None:
         try:
             data = data.swap_dims({"geom": space["unique_id"]})
             data = data.drop_vars("geom")


### PR DESCRIPTION
<!-- Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
  - This PR fixes #xyz
- [x] (If applicable) Documentation has been added / updated (for bug fixes / features).
- [x] (If applicable) Tests have been added.
- [x] CHANGELOG.rst has been updated (with summary of main changes).
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added.

### What kind of change does this PR introduce?

* When using `Query`, `space` gets assigned a `unique_id: None` if none are provided by the user. Thus, the line in `clip_polygon` was always True.

### Does this PR introduce a breaking change?


### Other information:
